### PR TITLE
Fixed typo in the Demo

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -246,7 +246,7 @@ pre{
 
 
 <span class="hljs-keyword">async</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">basicTerminalApp</span>(<span class="hljs-params"></span>) </span>{
-  term2.output(<span class="hljs-string">`1. Print Hello Wolrd
+  term2.output(<span class="hljs-string">`1. Print Hello World
 2. Add Two Numbers
 3. Exit`</span>)
 


### PR DESCRIPTION
While I was trying the project inside the demo I found a typo: the first command in the demo was "1. Print Hello Wolrd".
This PR fix that typo changing the command to: "1. Print Hello World" 😄 